### PR TITLE
The Curious Case of MR::processInitFunction

### DIFF
--- a/include/Game/Util/ActorInitUtil.h
+++ b/include/Game/Util/ActorInitUtil.h
@@ -17,9 +17,10 @@ namespace MR {
     // ??? makeInitActorPath(const char *, const char *);
     bool isValidInitActorPath(const char *, const char *);
 
-    void processInitFunction(LiveActor * pActor, const JMapInfoIter & rIter, const char * modelName, bool unk1, const char * funcName, bool unk2);
-    void processInitFunction(LiveActor * pActor, const char * modelName, bool unk1, bool unk2);
-    void processInitFunction(LiveActor * pActor, const char * modelName, bool unk1, const char * funcName, bool unk2);
+    void processInitFunction(LiveActor * pActor, const JMapInfoIter & rIter, const char * modelName, const char * animArchiveName, const char * funcName, bool unk2);
+    //This one needs a different name
+    void processInitFunction_(LiveActor * pActor, const char * modelName, const char * animArchiveName, bool unk2);
+    void processInitFunction(LiveActor * pActor, const char * modelName, const char * animArchiveName, const char * funcName, bool unk2);
 
     void initDefaultPos(LiveActor * pActor, const JMapInfoIter & rIter);
     void getDefaultPos(LiveActor * pActor, const JMapInfoIter & rIter);


### PR DESCRIPTION
While I was looking through the symbol maps, I noticed that these MR::processInitFunction labels were wrong, as r6 to the master function is a const char * and not a bool.

This is a draft for now because these functions are going to need some alternate names, due to the fact that 2 of them have identical function arguments `(LiveActor*, const char* , const char* , bool)`, but the second `const char*` is used for a different parameter to the master function.

Once these names are re-decided, the symbol maps should be updated.