### PR TITLE
Document FunctorV1M and FunctorV2M, and fix alignment

### DIFF
--- a/include/Game/Util/Functor.h
+++ b/include/Game/Util/Functor.h
@@ -51,7 +51,7 @@ namespace MR {
         }
 
         virtual FunctorBase* clone(JKRHeap *pHeap) const {
-            return new (pHeap, 0x1C) FunctorV1M(*this);
+            return new (pHeap, 0x14) FunctorV1M(*this);
         };
 
         T mCaller;
@@ -79,7 +79,7 @@ namespace MR {
         }
 
         virtual FunctorBase* clone(JKRHeap *pHeap) const {
-            return new (pHeap, 0x16) FunctorV2M(*this);
+            return new (pHeap, 0x1C) FunctorV2M(*this);
         }
 
         T mCaller;

--- a/include/Game/Util/Functor.h
+++ b/include/Game/Util/Functor.h
@@ -19,7 +19,8 @@ namespace MR {
             : mCaller(caller), mCallee(callee) {
         }
         
-        inline FunctorV0M(const FunctorV0M& ref) : FunctorV0M(ref.mCaller, ref.mCallee) {}
+        inline FunctorV0M(const FunctorV0M& ref)
+            : mCaller(ref.mCaller), mCallee(ref.mCallee) { }
 
         virtual void operator()() const {
             (mCaller->*mCallee)();
@@ -48,7 +49,8 @@ namespace MR {
 
         }
 
-        inline FunctorV1M(const FunctorV1M& ref) : FunctorV1M(ref.mCaller, ref.mCallee, ref.mArg0) {}
+        inline FunctorV1M(const FunctorV1M& ref) 
+            : mCaller(ref.mCaller), mCallee(ref.mCallee), mArg0(mArg0) {}
 
         virtual void operator()() const {
             (mCaller->*mCallee)(mArg0);
@@ -79,7 +81,7 @@ namespace MR {
         }
 
         inline FunctorV2M(const FunctorV2M& ref) :
-        FunctorV2M(ref.mCaller, ref.mCallee, ref.mArg0, ref.mArg1) { }
+        mCaller(ref.mCaller), mCallee(ref.mCallee), mArg0(ref.mArg0), mArg1(ref.mArg1) { }
 
         virtual void operator()() const {
             (mCaller->*mCallee)(mArg0, mArg1);

--- a/include/Game/Util/Functor.h
+++ b/include/Game/Util/Functor.h
@@ -24,7 +24,7 @@ namespace MR {
         }
 
         virtual FunctorBase* clone(JKRHeap *pHeap) const {
-            return new (pHeap, 0) FunctorV0M(mCaller, mCallee);
+            return new (pHeap, 0x14) FunctorV0M(*this);
         };
 
         T mCaller;
@@ -34,6 +34,63 @@ namespace MR {
     template<class T>
     static FunctorV0M<T *, void (T::*)()> Functor(T* caller, void (T::*callee)()) {
         return FunctorV0M<T *, void (T::*)()>(caller, callee);
+    }
+
+    template<typename T, typename U, typename V>
+    class FunctorV1M : public FunctorBase {
+        public:
+        inline FunctorV1M() { }
+
+        inline FunctorV1M(T caller, U callee, V arg0) :
+        mCaller(caller), mCallee(callee), mArg0(arg0) {
+
+        }
+
+        virtual void operator()() const {
+            (mCaller->*mCallee)(mArg0);
+        }
+
+        virtual FunctorBase* clone(JKRHeap *pHeap) const {
+            return new (pHeap, 0x1C) FunctorV1M(*this);
+        };
+
+        T mCaller;
+        U mCallee;
+        V mArg0;
+    };
+
+    template<typename T, typename U>
+    static FunctorV1M<T *, void (T::*)(U), U> Functor(T* caller, void (T::*callee)(U), U arg0) {
+        return FunctorV1M<T *, void (T::*)(U), U>(caller, callee, arg0);
+    }
+
+    template<typename T, typename U, typename V, typename W>
+    class FunctorV2M : public FunctorBase {
+        public:
+        inline FunctorV2M() { }
+
+        inline FunctorV2M(T caller, U calee, V arg0, W arg1) :
+        mCaller(caller), mCallee(calee), mArg0(arg0), mArg1(arg1) {
+
+        }
+
+        virtual void operator()() const {
+            (mCaller->*mCallee)(mArg0, mArg1);
+        }
+
+        virtual FunctorBase* clone(JKRHeap *pHeap) const {
+            return new (pHeap, 0x16) FunctorV2M(*this);
+        }
+
+        T mCaller;
+        U mCallee;
+        V mArg0;
+        W mArg1;
+    };
+
+    template<class T, typename U, typename V>
+    static FunctorV2M<T *, void (T::*)(U, V), U, V> Functor(T* caller, void (T::*callee)(U, V), U arg0, V arg1) {
+        return FunctorV2M<T *, void (T::*)(U, V), U, V>(caller, callee, arg0, arg1);
     }
 
     class FunctorV0F : public FunctorBase {

--- a/include/Game/Util/Functor.h
+++ b/include/Game/Util/Functor.h
@@ -18,13 +18,15 @@ namespace MR {
         inline FunctorV0M(T caller, U callee)
             : mCaller(caller), mCallee(callee) {
         }
+        
+        inline FunctorV0M(const FunctorV0M& ref) : FunctorV0M(ref.mCaller, ref.mCallee) {}
 
         virtual void operator()() const {
             (mCaller->*mCallee)();
         }
 
         virtual FunctorBase* clone(JKRHeap *pHeap) const {
-            return new (pHeap, 0x14) FunctorV0M(*this);
+            return new (pHeap, 0) FunctorV0M(*this);
         };
 
         T mCaller;
@@ -46,12 +48,14 @@ namespace MR {
 
         }
 
+        inline FunctorV1M(const FunctorV1M& ref) : FunctorV1M(ref.mCaller, ref.mCallee, ref.mArg0) {}
+
         virtual void operator()() const {
             (mCaller->*mCallee)(mArg0);
         }
 
         virtual FunctorBase* clone(JKRHeap *pHeap) const {
-            return new (pHeap, 0x14) FunctorV1M(*this);
+            return new (pHeap, 0) FunctorV1M(*this);
         };
 
         T mCaller;
@@ -74,12 +78,15 @@ namespace MR {
 
         }
 
+        inline FunctorV2M(const FunctorV2M& ref) :
+        FunctorV2M(ref.mCaller, ref.mCallee, ref.mArg0, ref.mArg1) { }
+
         virtual void operator()() const {
             (mCaller->*mCallee)(mArg0, mArg1);
         }
 
         virtual FunctorBase* clone(JKRHeap *pHeap) const {
-            return new (pHeap, 0x1C) FunctorV2M(*this);
+            return new (pHeap, 0) FunctorV2M(*this);
         }
 
         T mCaller;


### PR DESCRIPTION
Notes:
When looking through instances of the clone function, I noticed that r3's value was not what we were using in the `new` call. I've updated the calls to reflect my findings in IDA.
Reference addresses so you can check (SMG2 USA, all are one instruction before a `new` call):
- 80070F38 (V0M)
- 804BC678 (V1M)
- 804CB038 (V2M) This is 0x1C for some reason, it's also the only instance of clone for this class.